### PR TITLE
Improve node replace algorithm

### DIFF
--- a/demo/src/examples/LargeCollection.js
+++ b/demo/src/examples/LargeCollection.js
@@ -4,8 +4,8 @@ import Tree from '../../../src/TreeContainer';
 import Renderers from '../../../src/renderers';
 import { createEntry, constructTree } from '../toolbelt';
 
-const MIN_NUMBER_OF_PARENTS = 300;
-const MAX_NUMBER_OF_CHILDREN = 10;
+const MIN_NUMBER_OF_PARENTS = 500;
+const MAX_NUMBER_OF_CHILDREN = 15;
 const MAX_DEEPNESS = 4;
 
 const { Deletable, Expandable, Favorite } = Renderers;

--- a/index.d.ts
+++ b/index.d.ts
@@ -96,14 +96,14 @@ interface NodeRenderOptions {
   isDeletable: boolean;
 }
 
-export enum PICK_CHILDREN_FROM {
-  ORIGIN = 0,
-  CURRENT = 1
+export enum NODE_CHANGE_OPERATIONS {
+  CHANGE_NODE = 'CHANGE_NODE',
+  DELETE_NODE = 'DELETE_NODE'
 }
 
 interface Selectors {
   getNodeRenderOptions: (node: FlattenedNode) => NodeRenderOptions,
-  replaceNodeFromTree: (nodes: Node[], updatedNode: FlattenedNode, pickChildrenFrom?: PICK_CHILDREN_FROM) => Node[],
+  replaceNodeFromTree: (nodes: Node[], updatedNode: FlattenedNode, operation?: NODE_CHANGE_OPERATIONS) => Node[],
   deleteNodeFromTree: (nodes: Node[], nodeToDelete: FlattenedNode) => Node[],
   deleteNode: (node: FlattenedNode[]) => NodeAction,
   addNode: (node: FlattenedNode[]) => NodeAction,

--- a/src/selectors/__tests__/__snapshots__/nodes.test.js.snap
+++ b/src/selectors/__tests__/__snapshots__/nodes.test.js.snap
@@ -135,7 +135,8 @@ Array [
     "id": 0,
     "name": "Leaf 1",
     "state": Object {
-      "expanded": true,
+      "expanded": false,
+      "favorite": true,
     },
   },
   Object {

--- a/src/selectors/__tests__/nodes.test.js
+++ b/src/selectors/__tests__/nodes.test.js
@@ -59,7 +59,7 @@ describe('selectors -> nodes ->', () => {
       );
 
       expect(
-        nodeSelectors.replaceNodeFromTree(Nodes, updatedNode)
+        nodeSelectors.replaceNodeFromTree(Nodes, updatedNode.node)
       ).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
Same profiling on Large Collection example(increasing the number of rendered nodes to be ~230k) showed the following results:

# replaceNodeFromTree

## master
![image](https://user-images.githubusercontent.com/10208017/35765974-db8b5670-08c6-11e8-92b4-9dc7776221a4.png)

For a simple action `replaceNodeFromTree` takes ~500ms to run, this makes the UI look strange

## here
![image](https://user-images.githubusercontent.com/10208017/35766107-642a7af4-08c9-11e8-848b-352f05d23afb.png)

As the image shows the time that `replaceNodeFromTree` takes to run is now residual and the burden is on `getFlattenedTree`

It means that the next step will be to try to add some kind of memoization to `getFlattenedTree` so that it only needs flatten the strictly necessary nodes and keep the old ones in memory while still possible