### PR TITLE
Fixing typo

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,7 +108,7 @@ interface Selectors {
   deleteNodeFromTree: (nodes: Node[], nodeToDelete: FlattenedNode) => Node[],
   deleteNode: (node: FlattenedNode[]) => NodeAction,
   addNode: (node: FlattenedNode[]) => NodeAction,
-  udpateNode: (node: FlattenedNode, state: { [stateKey: string]: any }) => NodeAction
+  updateNode: (node: FlattenedNode, state: { [stateKey: string]: any }) => NodeAction
 }
 
 export const selectors: Selectors;

--- a/src/__tests__/TreeContainer.spec.js
+++ b/src/__tests__/TreeContainer.spec.js
@@ -6,7 +6,7 @@ import Tree from '../Tree';
 import { Nodes } from '../../testData/sampleTree';
 import { getFlattenedTree } from '../selectors/getFlattenedTree';
 import { UPDATE_TYPE } from '../contants';
-import { replaceNodeFromTree, udpateNode } from '../selectors/nodes';
+import { replaceNodeFromTree, updateNode } from '../selectors/nodes';
 
 describe('TreeContainer', () => {
   const setup = (children = () => <span></span>, extraProps = {}, context = {}) => {
@@ -56,7 +56,7 @@ describe('TreeContainer', () => {
 
       treeWrapper.simulate('change', {
         node: { ...getSampleNode(), state: { favorite: false, deletable: false } },
-        type: UPDATE_TYPE.UPDATE 
+        type: UPDATE_TYPE.UPDATE
       });
 
       expect(
@@ -73,7 +73,7 @@ describe('TreeContainer', () => {
 
       treeWrapper.simulate('change', {
         node: { ...getSampleNode(), state: { favorite: false, deletable: false } },
-        type: UPDATE_TYPE.UPDATE 
+        type: UPDATE_TYPE.UPDATE
       });
 
       expect(
@@ -98,16 +98,16 @@ describe('TreeContainer', () => {
           children: node.children ? expandAll(node.children) : []
         }));
 
-        const { treeWrapper, props } = setup(() => <span></span>, { 
+        const { treeWrapper, props } = setup(() => <span></span>, {
           extensions: {
             updateTypeHandlers: {
               [EXPAND_ALL]: expandAll
             }
           }
         });
-  
+
         treeWrapper.simulate('change', { node: getSampleNode(), type: EXPAND_ALL });
-  
+
         expect(
           props.onChange.mock.calls[0]
         ).toMatchSnapshot();
@@ -119,16 +119,16 @@ describe('TreeContainer', () => {
           { ...updatedNode, updated: true }
         );
 
-        const { treeWrapper, props } = setup(() => <span></span>, { 
+        const { treeWrapper, props } = setup(() => <span></span>, {
           extensions: {
             updateTypeHandlers: {
               [UPDATE_TYPE.UPDATE]: updateAndFlag
             }
           }
         });
-  
+
         treeWrapper.simulate('change', { node: getSampleNode(), type: UPDATE_TYPE.UPDATE });
-  
+
         expect(
           props.onChange.mock.calls[0]
         ).toMatchSnapshot();

--- a/src/renderers/Expandable.js
+++ b/src/renderers/Expandable.js
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { submitEvent } from '../eventWrappers';
-import { getNodeRenderOptions, udpateNode } from '../selectors/nodes';
+import { getNodeRenderOptions, updateNode } from '../selectors/nodes';
 import { Renderer } from '../shapes/rendererShapes';
 
 const Expandable = ({
@@ -20,11 +20,11 @@ const Expandable = ({
   const className = classNames({
     [iconsClassNameMap.expanded]: hasChildren && isExpanded,
     [iconsClassNameMap.collapsed]: hasChildren && !isExpanded,
-    [iconsClassNameMap.lastChild]: !hasChildren  
+    [iconsClassNameMap.lastChild]: !hasChildren
   });
 
-  const handleChange = () => onChange(udpateNode(node, { expanded: !isExpanded }));
-  
+  const handleChange = () => onChange(updateNode(node, { expanded: !isExpanded }));
+
   return (
     <span onDoubleClick={handleChange}>
       <i

--- a/src/renderers/Favorite.js
+++ b/src/renderers/Favorite.js
@@ -3,26 +3,26 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { submitEvent } from '../eventWrappers';
-import { getNodeRenderOptions, udpateNode } from '../selectors/nodes';
+import { getNodeRenderOptions, updateNode } from '../selectors/nodes';
 import { Renderer } from '../shapes/rendererShapes';
 
 const Favorite = ({
   onChange,
   node,
-  iconsClassNameMap = { 
+  iconsClassNameMap = {
     favorite: 'mi mi-star',
     notFavorite: 'mi mi-star-border'
   },
   children }) => {
-  const { isFavorite } = getNodeRenderOptions(node); 
+  const { isFavorite } = getNodeRenderOptions(node);
 
   const className = classNames({
     [iconsClassNameMap.favorite]: isFavorite,
     [iconsClassNameMap.notFavorite]: !isFavorite,
   });
 
-  const handleChange = () => onChange(udpateNode(node, { favorite: !isFavorite }));
-  
+  const handleChange = () => onChange(updateNode(node, { favorite: !isFavorite }));
+
   return (
     <span>
       <i

--- a/src/renderers/__tests__/Expandable.test.js
+++ b/src/renderers/__tests__/Expandable.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import Expandable from '../Expandable';
 import { KEY_CODES } from '../../eventWrappers';
-import { udpateNode } from '../../selectors/nodes';
+import { updateNode } from '../../selectors/nodes';
 
 describe('renderers Expandable', () => {
   const findExpandIcon = wrapper => wrapper.find('i');
@@ -16,7 +16,7 @@ describe('renderers Expandable', () => {
         name: 'Node 1',
         state,
         deepness: 0,
-        children: [{}]        
+        children: [{}]
       },
       iconsClassNameMap: {
         expanded: 'expanded',
@@ -41,12 +41,12 @@ describe('renderers Expandable', () => {
 
       it('clicking should call onChange with the correct params', () => {
         const { expandIconWrapper, props } = setup({ expanded: true });
-        
+
         expandIconWrapper.simulate('click');
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: false }
           )
         );
@@ -54,12 +54,12 @@ describe('renderers Expandable', () => {
 
       it('pressing enter should call onChange with the correct params', () => {
         const { expandIconWrapper, props } = setup({ expanded: true });
-        
+
         expandIconWrapper.simulate('keyDown', { keyCode: KEY_CODES.Enter });
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: false }
           )
         )
@@ -67,12 +67,12 @@ describe('renderers Expandable', () => {
 
       it('double clicking in the parent node should call onChange with the correct params', () => {
         const { props, wrapper } = setup({ expanded: true });
-        
+
         wrapper.first().simulate('doubleClick');
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: false }
           )
         );
@@ -82,18 +82,18 @@ describe('renderers Expandable', () => {
     describe('when collapsed', () => {
       it('should render a with the supplied className when expanded', () => {
         const { expandIconWrapper, props } = setup({ expanded: false });
-        
+
         expect(expandIconWrapper.hasClass(props.iconsClassNameMap.collapsed)).toBeTruthy();
       })
 
       it('clicking should call onChange with the correct params', () => {
         const { expandIconWrapper, props } = setup({ expanded: false });
-        
+
         expandIconWrapper.simulate('click');
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: true }
           )
         )
@@ -101,12 +101,12 @@ describe('renderers Expandable', () => {
 
       it('pressing enter should call onChange with the correct params', () => {
         const { expandIconWrapper, props } = setup({ expanded: false });
-        
+
         expandIconWrapper.simulate('keyDown', { keyCode: KEY_CODES.Enter });
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: true }
           )
         )
@@ -114,12 +114,12 @@ describe('renderers Expandable', () => {
 
       it('double clicking in the parent node should call onChange with the correct params', () => {
         const { props, wrapper } = setup({ expanded: false });
-        
+
         wrapper.first().simulate('doubleClick');
 
         expect(props.onChange).toHaveBeenCalledWith(
-          udpateNode(
-            props.node, 
+          updateNode(
+            props.node,
             { expanded: true }
           )
         );

--- a/src/renderers/__tests__/Favorite.test.js
+++ b/src/renderers/__tests__/Favorite.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import Favorite from '../Favorite';
 import { KEY_CODES } from '../../eventWrappers';
-import { udpateNode } from '../../selectors/nodes';
+import { updateNode } from '../../selectors/nodes';
 
 describe('renderers Favorite', () => {
   const findFavoriteIcon = wrapper => wrapper.find('i');
@@ -16,7 +16,7 @@ describe('renderers Favorite', () => {
         name: 'Node 1',
         state,
         deepness: 0,
-        children: [{}]        
+        children: [{}]
       },
       iconsClassNameMap: {
         favorite: 'fav',
@@ -33,7 +33,7 @@ describe('renderers Favorite', () => {
 
   describe('when favorite', () => {
     const setupFavorite = (extraProps = {}) => setup({ favorite: true }, extraProps);
-    
+
     it('should render a with the supplied className', () => {
       const { favoriteIconWrapper, props } = setupFavorite();
 
@@ -42,12 +42,12 @@ describe('renderers Favorite', () => {
 
     it('clicking should call onChange with the correct params', () => {
       const { favoriteIconWrapper, props } = setupFavorite();
-      
+
       favoriteIconWrapper.simulate('click');
 
       expect(props.onChange).toHaveBeenCalledWith(
-        udpateNode(
-          props.node, 
+        updateNode(
+          props.node,
           { favorite: false }
         )
       );
@@ -55,12 +55,12 @@ describe('renderers Favorite', () => {
 
     it('pressing enter should call onChange with the correct params', () => {
       const { favoriteIconWrapper, props } = setupFavorite();
-      
+
       favoriteIconWrapper.simulate('keyDown', { keyCode: KEY_CODES.Enter });
 
       expect(props.onChange).toHaveBeenCalledWith(
-        udpateNode(
-          props.node, 
+        updateNode(
+          props.node,
           { favorite: false }
         )
       )
@@ -69,21 +69,21 @@ describe('renderers Favorite', () => {
 
   describe('when not favorite', () => {
     const setupNotFavorite = (extraProps = {}) => setup({ favorite: false }, extraProps);
-    
+
     it('should render a with the supplied className', () => {
       const { favoriteIconWrapper, props } = setupNotFavorite();
-      
+
       expect(favoriteIconWrapper.hasClass(props.iconsClassNameMap.notFavorite)).toBeTruthy();
     })
 
     it('clicking should call onChange with the correct params', () => {
       const { favoriteIconWrapper, props } = setupNotFavorite();
-      
+
       favoriteIconWrapper.simulate('click');
 
       expect(props.onChange).toHaveBeenCalledWith(
-        udpateNode(
-          props.node, 
+        updateNode(
+          props.node,
           { favorite: true }
         )
       )
@@ -91,12 +91,12 @@ describe('renderers Favorite', () => {
 
     it('pressing enter should call onChange with the correct params', () => {
       const { favoriteIconWrapper, props } = setupNotFavorite();
-      
+
       favoriteIconWrapper.simulate('keyDown', { keyCode: KEY_CODES.Enter });
 
       expect(props.onChange).toHaveBeenCalledWith(
-        udpateNode(
-          props.node, 
+        updateNode(
+          props.node,
           { favorite: true }
         )
       )

--- a/src/selectors/__tests__/nodes.test.js
+++ b/src/selectors/__tests__/nodes.test.js
@@ -14,7 +14,7 @@ describe('selectors -> nodes ->', () => {
       deepFreeze(originalNode);
 
       expect(
-        nodeSelectors.udpateNode(originalNode, { favorite: true, expanded: false } )
+        nodeSelectors.updateNode(originalNode, { favorite: true, expanded: false } )
       ).toMatchSnapshot();
     });
 
@@ -53,7 +53,7 @@ describe('selectors -> nodes ->', () => {
     it('replaceNodeFromTree should replace a node in the tree without mutations', () => {
       deepFreeze(Nodes);
 
-      const updatedNode =  nodeSelectors.udpateNode(
+      const updatedNode =  nodeSelectors.updateNode(
         getSampleNode(),
         { favorite: true, expanded: false }
       );

--- a/src/selectors/nodes.js
+++ b/src/selectors/nodes.js
@@ -7,7 +7,7 @@ export const getNodeRenderOptions = createSelector(
   (node => (node.state || {}).expanded),
   (node => (node.state || {}).favorite),
   (node => (node.state || {}).deletable),
-  (node => node.children), 
+  (node => node.children),
   (expanded, favorite, deletable, children = []) => ({
     hasChildren: !!children.length,
     isExpanded: !!expanded,
@@ -25,14 +25,14 @@ const NODE_OPERATION_TYPES = {
 
 const NODE_CHANGE_OPERATIONS = {
   CHANGE_NODE: (nodes, updatedNode) => nodes.map(n => n.id === updatedNode.id ? omit(updatedNode, FLATTEN_TREE_PROPERTIES) : n),
-  DELETE_NODE: (nodes, updatedNode) => nodes.filter(n => n.id !== updatedNode.id) 
+  DELETE_NODE: (nodes, updatedNode) => nodes.filter(n => n.id !== updatedNode.id)
 }
 
 export const replaceNodeFromTree = (nodes, updatedNode, operation = NODE_OPERATION_TYPES.CHANGE_NODE) => {
   if (!NODE_CHANGE_OPERATIONS[operation]) {
     return nodes;
   }
-  
+
   const { parents } = updatedNode;
 
   if (!parents.length) {
@@ -46,8 +46,8 @@ export const replaceNodeFromTree = (nodes, updatedNode, operation = NODE_OPERATI
   return [
     ...preSiblings,
     {
-      ...nodes[parentIndex], 
-      ...nodes[parentIndex].children ? 
+      ...nodes[parentIndex],
+      ...nodes[parentIndex].children ?
         { children: replaceNodeFromTree(
             nodes[parentIndex].children,
             { ...updatedNode, parents: parents.slice(1) },
@@ -67,7 +67,7 @@ export const deleteNodeFromTree = (nodes, deletedNode) => {
   );
 }
 
-export const udpateNode = (originalNode, newState) => ({
+export const updateNode = (originalNode, newState) => ({
   node: {
     ...originalNode,
     state : {


### PR DESCRIPTION
Hiya!

Great module! I noticed that "updateNode" is listed as "udpateNode" everywhere, so here's a pull request fixing that typo!
