### PR TITLE
Prop type fix

### DIFF
--- a/src/shapes/nodeShapes.js
+++ b/src/shapes/nodeShapes.js
@@ -8,7 +8,7 @@ export const NodeState = {
 
 const BasicNode = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-  name: PropTypes.string.isRequired,
+  name: PropTypes.string,
   state: PropTypes.shape(NodeState)
 };
 

--- a/src/shapes/rendererShapes.js
+++ b/src/shapes/rendererShapes.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { FlattenedNode } from './nodeShapes';
 
 export const Renderer = {
-  measure: PropTypes.func.isRequired,
+  measure: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   node: PropTypes.shape(FlattenedNode)
 };


### PR DESCRIPTION
Removing Proptype's _isRequired_ from:
1. _NodeShape_'s _name_ property.
2. _Renderer_'s _measure_ property.