### PR TITLE
fix: 🐛 added children as optional prop for Renderer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ export interface RendererProps<T> {
   onChange: (updateParams: NodeAction) => void;
   node: FlattenedNode;
   iconsClassNameMap?: T;
+  children?: React.ReactNode;
 }
 
 type DeletableRenderProps = RendererProps<{delete?: string}>;


### PR DESCRIPTION
Closes https://github.com/diogofcunha/react-virtualized-tree/issues/77