### PR TITLE
fix: InjectedRendererProps and CustomRendererProps types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,8 +53,8 @@ export interface RendererProps<T> {
   children?: React.ReactNode;
 }
 
-export type InjectedRendererProps = Omit<RendererProps<T>, 'iconsClassNameMap'>;
-export type CustomRendererProps = Omit<RendererProps<T>, 'style'>;
+export interface InjectedRendererProps<T> extends Omit<RendererProps<T>, 'iconsClassNameMap'> {}
+export interface CustomRendererProps<T> extends Omit<RendererProps<T>, 'style'> {}
 
 type DeletableRenderProps = CustomRendererProps<{delete?: string}>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,8 +53,8 @@ export interface RendererProps<T> {
   children?: React.ReactNode;
 }
 
-export interface InjectedRendererProps<T> extends Omit<RendererProps<T>, 'iconsClassNameMap'> {}
-export interface CustomRendererProps<T> extends Omit<RendererProps<T>, 'style'> {}
+export type InjectedRendererProps<T> = Omit<RendererProps<T>, 'iconsClassNameMap'>;
+export type CustomRendererProps<T> = Omit<RendererProps<T>, 'style'>;
 
 type DeletableRenderProps = CustomRendererProps<{delete?: string}>;
 


### PR DESCRIPTION
I noticed an error with typescript generic typings. Tried it with Typescript 3.0.1 and 3.3.3 - both throw a compilation error. Merge, please!