### PR TITLE
fix: made sure width is injected in the tree

### DIFF
--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -53,6 +53,7 @@ export default class TreeContainer extends React.Component {
         NodeRenderer={this.props.children}
         scrollToIndex={rowIndex}
         scrollToAlignment={this.props.scrollToAlignment}
+        width={this.props.width}
       />
     );
   }


### PR DESCRIPTION
- Add missing width property on TreeContainter, used by Tree;

This was mentioned in [#56](https://github.com/diogofcunha/react-virtualized-tree/pull/56) ;)