### PR TITLE
Add a rowIndex prop for keyboard navigation

### DIFF
--- a/demo/src/examples/Basic/index.js
+++ b/demo/src/examples/Basic/index.js
@@ -23,6 +23,21 @@ class BasicTree extends Component {
     nodes: Nodes,
     availableRenderers: [Expandable, Deletable, Favorite],
     selectedRenderers: [Expandable, NodeNameRenderer],
+    currentIndex: null,
+  };
+
+  treeRef = React.createRef();
+
+  handleKeyDown = e => {
+    const {startIndex, stopIndex} = this.treeRef.current;
+    const length = stopIndex - startIndex + 1;
+    if (e.keyCode === 38) {
+      this.setState(prev => ({currentIndex: prev.currentIndex - 1 < 0 ? 0 : (prev.currentIndex - 1) % length}));
+    } else if (e.keyCode === 40) {
+      this.setState(prev => ({currentIndex: (prev.currentIndex + 1) % length}));
+    } else if (e.keyCode === 32) {
+      console.log(this.selectedNode);
+    }
   };
 
   handleRendererMove = (dragIndex, hoverIndex) => {
@@ -81,7 +96,17 @@ class BasicTree extends Component {
     }));
   };
 
+  getStyle = (style, p) => {
+    if (p.index === this.state.currentIndex) {
+      this.selectedNode = p.node;
+    }
+    return {...style, border: p.index === this.state.currentIndex ? 'solid 1px black' : ''};
+  };
+
   render() {
+    if (this.treeRef.current) {
+      console.log(this.treeRef.current.startIndex, this.treeRef.current.stopIndex, this.state.currentIndex);
+    }
     const renderersAvailableForAdd = this.state.availableRenderers.filter(
       r => this.state.selectedRenderers.indexOf(r) === -1,
     );
@@ -105,9 +130,16 @@ class BasicTree extends Component {
           </Grid.Column>
           <Grid.Column>
             <Header as="h4">Ouput tree</Header>
-            <div style={{height: 200}}>
-              <Tree nodes={this.state.nodes} onChange={this.handleChange}>
-                {({style, ...p}) => <div style={style}>{this.createNodeRenderer(this.state.selectedRenderers, p)}</div>}
+            <div tabIndex={-1} onKeyDown={this.handleKeyDown} style={{height: 200}}>
+              <Tree
+                scrollToIndex={this.state.currentIndex}
+                ref={this.treeRef}
+                nodes={this.state.nodes}
+                onChange={this.handleChange}
+              >
+                {({style, ...p}) => (
+                  <div style={this.getStyle(style, p)}>{this.createNodeRenderer(this.state.selectedRenderers, p)}</div>
+                )}
               </Tree>
             </div>
           </Grid.Column>

--- a/demo/src/examples/Filterable.js
+++ b/demo/src/examples/Filterable.js
@@ -25,6 +25,8 @@ class Filterable extends Component {
     groupsEnabled: true,
   };
 
+  treeRef = React.createRef();
+
   get _groupProps() {
     return this.state.groupsEnabled
       ? {
@@ -61,6 +63,9 @@ class Filterable extends Component {
   };
 
   render() {
+    if (this.treeRef.current) {
+      console.log(this.treeRef.current.startIndex, this.treeRef.current.stopIndex);
+    }
     return (
       <div>
         <Checkbox
@@ -73,7 +78,7 @@ class Filterable extends Component {
         <FilteringContainer nodes={this.state.nodes} {...this._groupProps}>
           {({nodes}) => (
             <div style={{height: 500}}>
-              <Tree nodes={nodes} onChange={this.handleChange}>
+              <Tree ref={this.treeRef} nodes={nodes} onChange={this.handleChange}>
                 {({style, node, ...rest}) => (
                   <div style={style}>
                     <Expandable node={node} {...rest}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-virtualized-tree",
-  "version": "2.0.2",
+  "name": "react-virtualized-tree-fork",
+  "version": "1.0.0",
   "description": "react-virtualized-tree React component",
   "main": "lib/index.js",
   "module": "es/index.js",
@@ -120,10 +120,8 @@
     "bracketSpacing": false,
     "jsxBracketSameLine": false
   },
-  "author": "Diogo Cunha",
-  "homepage": "https://diogofcunha.github.io/react-virtualized-tree/",
+  "author": "Ryan Zhu",
   "license": "MIT",
-  "repository": "https://github.com/diogofcunha/react-virtualized-tree/",
   "keywords": [
     "react",
     "tree",

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -67,7 +67,7 @@ export default class Tree extends React.Component {
   };
 
   render() {
-    const {nodes, width, scrollToIndex, scrollToAlignment} = this.props;
+    const {nodes, width, scrollToIndex, scrollToAlignment, onRowsRendered} = this.props;
 
     return (
       <AutoSizer disableWidth={Boolean(width)}>
@@ -82,6 +82,7 @@ export default class Tree extends React.Component {
             width={width || autoWidth}
             scrollToIndex={scrollToIndex}
             scrollToAlignment={scrollToAlignment}
+            onRowsRendered={onRowsRendered}
           />
         )}
       </AutoSizer>

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -42,9 +42,14 @@ export default class TreeContainer extends React.Component {
     this.props.onChange(updatedNodes);
   };
 
+  _onRowsRendered = ({startIndex, stopIndex}) => {
+    this.startIndex = startIndex;
+    this.stopIndex = stopIndex;
+  };
+
   render() {
     const flattenedTree = getFlattenedTree(this.props.nodes);
-    const rowIndex = getRowIndexFromId(flattenedTree, this.props.scrollToId);
+    const rowIndex = this.props.scrollToIndex || getRowIndexFromId(flattenedTree, this.props.scrollToId);
     return (
       <Tree
         nodeMarginLeft={this.props.nodeMarginLeft}
@@ -54,6 +59,7 @@ export default class TreeContainer extends React.Component {
         scrollToIndex={rowIndex}
         scrollToAlignment={this.props.scrollToAlignment}
         width={this.props.width}
+        onRowsRendered={this._onRowsRendered}
       />
     );
   }
@@ -70,8 +76,10 @@ TreeContainer.propTypes = {
   width: PropTypes.number,
   scrollToId: PropTypes.number,
   scrollToAlignment: PropTypes.string,
+  scrollToIndex: PropTypes.number,
 };
 
 TreeContainer.defaultProps = {
   nodeMarginLeft: 30,
+  scrollToIndex: null,
 };

--- a/src/UnstableFastTree.js
+++ b/src/UnstableFastTree.js
@@ -27,6 +27,11 @@ export default class UnstableFastTree extends React.Component {
     this.props.onChange(nodes);
   };
 
+  _onRowsRendered = ({startIndex, stopIndex}) => {
+    this.startIndex = startIndex;
+    this.stopIndex = stopIndex;
+  };
+
   render() {
     return (
       <Tree
@@ -34,6 +39,7 @@ export default class UnstableFastTree extends React.Component {
         nodes={this.props.nodes}
         onChange={this.handleChange}
         NodeRenderer={this.props.children}
+        onRowsRendered={this._onRowsRendered}
       />
     );
   }
@@ -53,8 +59,10 @@ UnstableFastTree.propTypes = {
   nodeMarginLeft: PropTypes.number,
   width: PropTypes.number,
   scrollToId: PropTypes.number,
+  scrollToIndex: PropTypes.number,
 };
 
 UnstableFastTree.defaultProps = {
   nodeMarginLeft: 30,
+  scrollToIndex: null,
 };


### PR DESCRIPTION
I have a requirement that the tree should support keyboard navigation. But with `scrollToId` is not enough to do it.

There is a call back function named `onRowsRendered` in `react-virtualized` and it can be used to fetch the `startIndex` and `stopIndex`.  Reference link: https://github.com/bvaughn/react-virtualized/issues/581

Wrapper component can pass a ref to get these 2 properties.

Looking forward for feedbacks.
I'll use the forked repo from my own temporarily. 