### PR TITLE
Make filter container indexSearch prop optional in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -103,7 +103,7 @@ export interface FilteringContainerProps {
   selectedGroup?: string;
   groupRenderer?: React.StatelessComponent<GroupRendererProps> | React.Component<GroupRendererProps>;
   onSelectedGroupChange?: (c: string) => void;
-  indexSearch: (searchTerm: string, nodes: FlattenedNode[]) => (node: FlattenedNode) => boolean;
+  indexSearch?: (searchTerm: string, nodes: FlattenedNode[]) => (node: FlattenedNode) => boolean;
 }
 
 export class FilteringContainer extends React.Component<FilteringContainerProps> {}


### PR DESCRIPTION
The new indexSearch prop introduced for FilteringContainer in #123 is great and has a default so if I'm not mistaken it should be listed as optional in the types.

My TypeScript is throwing a tantrum at the moment because it's expecting me to pass a custom function for this

Thanks for all the work on this package!