### PR TITLE
Replaced margin for padding

### DIFF
--- a/src/Tree.js
+++ b/src/Tree.js
@@ -43,7 +43,7 @@ export default class Tree extends React.Component {
         key={key}
         style={{
           ...style,
-          marginLeft: node.deepness * nodeMarginLeft,
+          paddingLeft: node.deepness * nodeMarginLeft,
           userSelect: 'none',
           cursor: 'pointer',
         }}


### PR DESCRIPTION
This PR should fix a problem with setting the wrong row width.

Actual state:
![obrazek](https://user-images.githubusercontent.com/44465269/89768270-ad751780-dafb-11ea-9ec1-7368744340ab.png)

Fixed state:
![obrazek](https://user-images.githubusercontent.com/44465269/89768161-8c142b80-dafb-11ea-95c2-6f15647f02c7.png)

As you can see by setting a gap by margin row will not respect the parent container width. With setting a gap by padding you have guarantee you will see the whole row.