### PR TITLE
Allow string in scrollToId

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,7 @@ export interface TreeProps {
   children: <T = any>(props: RendererProps<T>) => JSX.Element;
   nodeMarginLeft?: number;
   width?: number;
-  scrollToId?: number;
+  scrollToId?: NodeId;
   scrollToAlignment?: string;
 }
 

--- a/src/TreeContainer.js
+++ b/src/TreeContainer.js
@@ -68,7 +68,7 @@ TreeContainer.propTypes = {
   children: PropTypes.func.isRequired,
   nodeMarginLeft: PropTypes.number,
   width: PropTypes.number,
-  scrollToId: PropTypes.number,
+  scrollToId: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
   scrollToAlignment: PropTypes.string,
 };
 

--- a/src/UnstableFastTree.js
+++ b/src/UnstableFastTree.js
@@ -52,7 +52,7 @@ UnstableFastTree.propTypes = {
   children: PropTypes.func.isRequired,
   nodeMarginLeft: PropTypes.number,
   width: PropTypes.number,
-  scrollToId: PropTypes.number,
+  scrollToId: PropTypes.oneOf([PropTypes.number, PropTypes.string]),
 };
 
 UnstableFastTree.defaultProps = {


### PR DESCRIPTION
`NodeId` can be `string` or `number` but `scrollToId` only allows `number`.