### PR TITLE
Iterative version of getFlattenedTree for improved performance on large datasets

### DIFF
--- a/src/selectors/getFlattenedTree.js
+++ b/src/selectors/getFlattenedTree.js
@@ -1,17 +1,33 @@
 export const isNodeExpanded = node => node.state && node.state.expanded;
 export const nodeHasChildren = node => node.children && node.children.length;
 
-export const getFlattenedTree = (nodes, parents = []) =>
-  nodes.reduce((flattenedTree, node) => {
+export const getFlattenedTree = (nodes, parents = []) => {
+  const flattenedTree = [];
+  const flattenNodes = [];
+
+  for (const node of nodes) {
+    flattenNodes.push({node, parents});
+  }
+
+  while (flattenNodes.length > 0) {
+    const {node, parents} = flattenNodes.pop();
+
     const deepness = parents.length;
     const nodeWithHelpers = {...node, deepness, parents};
 
-    if (!nodeHasChildren(node) || !isNodeExpanded(node)) {
-      return [...flattenedTree, nodeWithHelpers];
-    }
+    flattenedTree.push(nodeWithHelpers);
 
-    return [...flattenedTree, nodeWithHelpers, ...getFlattenedTree(node.children, [...parents, node.id])];
-  }, []);
+    if (nodeHasChildren(node) && isNodeExpanded(node)) {
+      const childParents = [...parents, node.id];
+
+      for (let i = node.children.length - 1; i >= 0; i--) {
+        flattenNodes.push({node: node.children[i], parents: childParents});
+      }
+    }
+  }
+
+  return flattenedTree;
+};
 
 export const getFlattenedTreePaths = (nodes, parents = []) => {
   const paths = [];


### PR DESCRIPTION
Addresses #84 

Thank you for the great library, it has worked really well and achieved amazing results with our project.

Recently, we had a performance issue with a particularly large dataset. The tree contained roughly 140k nodes with the structure being 14 nodes containing around 10k direct children each. 

This would take around 1-2 minutes to render. 

Quick profiling showed that `getFlattenedTree` was taking around 1 minute to complete.
<img width="1040" alt="Screen Shot 2021-04-16 at 1 08 31 PM" src="https://user-images.githubusercontent.com/9285017/115079116-886c4c00-9eb5-11eb-86b2-0b90095c49fc.png">

After changing the `getFlattenedTree` to an iterative implementation, the render time decreased drastically with profiling showing all `getFlattenedTree` calls completing within 100ms.  
<img width="760" alt="Screen Shot 2021-04-16 at 1 09 40 PM" src="https://user-images.githubusercontent.com/9285017/115079113-87d3b580-9eb5-11eb-9c6d-db49d18fa50d.png">

Would appreciate any comments or thoughts