### PR TITLE
Fix to support larger datasets

### DIFF
--- a/src/selectors/getFlattenedTree.js
+++ b/src/selectors/getFlattenedTree.js
@@ -1,32 +1,41 @@
 export const isNodeExpanded = node => node.state && node.state.expanded;
 export const nodeHasChildren = node => node.children && node.children.length;
 
-export const getFlattenedTree = (nodes, parents = []) =>
-  nodes.reduce((flattenedTree, node) => {
+export const getFlattenedTree = (nodes, parents = []) => {
+  const flattenedTree = [];
+  const stack = [...nodes.map(node => ({node, parents}))];
+
+  while (stack.length > 0) {
+    const {node, parents} = stack.shift();
     const deepness = parents.length;
     const nodeWithHelpers = {...node, deepness, parents};
 
     if (!nodeHasChildren(node) || !isNodeExpanded(node)) {
-      return [...flattenedTree, nodeWithHelpers];
-    }
-
-    return [...flattenedTree, nodeWithHelpers, ...getFlattenedTree(node.children, [...parents, node.id])];
-  }, []);
-
-export const getFlattenedTreePaths = (nodes, parents = []) => {
-  const paths = [];
-
-  for (const node of nodes) {
-    const {id} = node;
-
-    if (!nodeHasChildren(node) || !isNodeExpanded(node)) {
-      paths.push(parents.concat(id));
+      flattenedTree.push(nodeWithHelpers);
     } else {
-      paths.push(parents.concat(id));
-      paths.push(...getFlattenedTreePaths(node.children, [...parents, id]));
+      flattenedTree.push(nodeWithHelpers);
+      stack.unshift(...node.children.map(child => ({node: child, parents: [...parents, node.id]})));
     }
   }
 
+  return flattenedTree;
+};
+
+export const getFlattenedTreePaths = (nodes, parents = []) => {
+  const paths = [];
+  const stack = [...nodes.map(node => ({node, parents}))];
+
+  while (stack.length > 0) {
+    const {node, parents} = stack.shift();
+    const {id} = node;
+
+    if (!nodeHasChildren(node) || !isNodeExpanded(node)) {
+      paths.push([...parents, id]);
+    } else {
+      paths.push([...parents, id]);
+      stack.unshift(...node.children.map(child => ({node: child, parents: [...parents, id]})));
+    }
+  }
   return paths;
 };
 

--- a/src/state/TreeStateModifiers.js
+++ b/src/state/TreeStateModifiers.js
@@ -27,7 +27,7 @@ export default class TreeStateModifiers {
   static editNodeAt = (state, index, nodeUpdate) => {
     const node = TreeState.getNodeAt(state, index);
     const updatedNode = typeof nodeUpdate === 'function' ? nodeUpdate(node) : nodeUpdate;
-    const flattenedTree = [...state.flattenedTree];
+    let flattenedTree = [...state.flattenedTree];
     const flattenedNodeMap = flattenedTree[index];
     const parents = flattenedNodeMap.slice(0, flattenedNodeMap.length - 1);
 
@@ -37,7 +37,11 @@ export default class TreeStateModifiers {
       if (isNodeExpanded(updatedNode)) {
         const updatedNodeSubTree = getFlattenedTreePaths([updatedNode], parents);
 
-        flattenedTree.splice(index + 1, 0, ...updatedNodeSubTree.slice(1));
+        flattenedTree = [
+          ...flattenedTree.slice(0, index + 1),
+          ...updatedNodeSubTree.slice(1),
+          ...flattenedTree.slice(index + 1 + numberOfVisibleDescendants),
+        ];
       } else {
         flattenedTree.splice(index + 1, numberOfVisibleDescendants);
       }


### PR DESCRIPTION
Previous approach with recursive call to `getFlattenedTree` and `getFlattenedTreePaths` was prone to "Maximum call stack sizeexceeded" error or slow rendering (couple of minutes). Changed it to iterative approach to avoid such behaviour.

Couple of times I encountered a maximum argument size issue ([explained here ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply#using_apply_and_built-in_functions)) caused by `Array.splice` so I've moved it out in favor of this not as pretty but effective solution.
